### PR TITLE
Add new config to allow customizing the default/relation based prospector/input

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -49,3 +49,8 @@ options:
     default: ""
     description: |
       A YAML list which will be injected to define additional prospectors/inputs.
+  extra_configs_default_input:
+    type: string
+    default: ""
+    description: |
+      A YAML list of config options to include in the default input. extra_inputs will not be affected.

--- a/templates/filebeat-5.yml
+++ b/templates/filebeat-5.yml
@@ -16,6 +16,9 @@ filebeat:
       scan_frequency: 10s
       harvester_buffer_size: {{ harvester_buffer_size }}
       max_bytes: {{ max_bytes }}
+      {% if extra_configs_default_input -%}
+      {{ extra_configs_default_input|indent(6) }}
+      {% endif -%}
       fields:
         juju_model_name: {{ juju_model_name }}
         juju_model_uuid: {{ juju_model_uuid }}

--- a/templates/filebeat-6.yml
+++ b/templates/filebeat-6.yml
@@ -18,6 +18,9 @@ filebeat:
       harvester_buffer_size: {{ harvester_buffer_size }}
       max_bytes: {{ max_bytes }}
       fields_under_root: false
+      {% if extra_configs_default_input -%}
+      {{ extra_configs_default_input|indent(6) }}
+      {% endif -%}
       fields:
         type: logpath-logs
         juju_model_name: {{ juju_model_name }}

--- a/templates/filebeat-7.yml
+++ b/templates/filebeat-7.yml
@@ -17,6 +17,9 @@ filebeat:
       harvester_buffer_size: {{ harvester_buffer_size }}
       max_bytes: {{ max_bytes }}
       fields_under_root: false
+      {% if extra_configs_default_input -%}
+      {{ extra_configs_default_input|indent(6) }}
+      {% endif -%}
       fields:
         type: logpath-logs
         juju_model_name: {{ juju_model_name }}


### PR DESCRIPTION
Add `extra_configs_default_input` config option which is a YAML string that will be inserted "as is" in the config file.

The aim for this is to allow other config tweaks not explicitly exposed in config.yaml, e.g:
 - for high load services, on a initial deploy set `tail_files: true` in order to avoid pushing a *lot* of events that the graylog/logstash/elasticsearch might not be able to handle
 -  to add python multiline support: 
     ```
    multiline:
      pattern: "^([0-9]{4}-[0-9]{2}-[0-9]{2}|[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3})"
      negate: true
      match: after
    ```