### PR TITLE
Split bases to fix install errors

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -10,10 +10,8 @@ parts:
   charm:
     source: ./
     plugin: reactive
-    build-snaps: 
-      # if it is build with charm/3.x it cannot be installed on bionic
-      # Error: pip requires Python '>=3.7' but the running Python is 3.6.9    
-      - charm/2.x/stable
+    build-snaps:
+      - charm
 
 bases:
   - build-on:
@@ -25,10 +23,20 @@ bases:
         channel: "22.04"
         architectures:
           - amd64
+  - build-on:
+    - name: ubuntu
+      channel: "20.04"
+      architectures: ["amd64"]
+    run-on:
       - name: ubuntu
         channel: "20.04"
         architectures:
           - amd64
+  - build-on:
+    - name: ubuntu
+      channel: "18.04"
+      architectures: ["amd64"]
+    run-on:
       - name: ubuntu
         channel: "18.04"
         architectures:


### PR DESCRIPTION
`charm` was pinned to 2.x, which uses a bundled version of python (I think python3.6).
See https://forum.snapcraft.io/t/2-x-and-3-x-tracks-for-the-charm-snap/31937 . This means that the requirements resolved from wheelhouse.txt at build time are not necessarily the same requirements as would be installed at deploy time,
because the python version may be different.
So this caused missing python package dependencies during install on focal and jammy.

According to https://github.com/juju/charm-tools/issues/640 , this can be fixed by switching to `charm` 3.x,
and separating the bases
so the charm for each base is built on that base.
This ensures that the same version of python is used at build time as at runtime.

Fixes: #112
Fixes: #114