### PR TITLE
Pin immutables to <0.16 on bionic to fix install

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,0 +1,3 @@
+# NOTE: temporary change; revert once fixed in layer-basic.
+# see https://github.com/canonical/layer-basic/issues/223
+immutables<0.16;python_version < '3.8'


### PR DESCRIPTION
immutables >= 0.16 requires setuptools >= 42,
but setuptools is pinned to <42 for python 3.8 (for bionic base).

This should ultimately be fixed in layer-basic,
but we can temporarily pin it here to become unblocked.

ref.
- https://github.com/canonical/layer-basic/issues/223
- https://github.com/canonical/layer-basic/pull/228

Fixes: #113