### PR TITLE
Fix cython build in charmcraft build

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -10,6 +10,8 @@ parts:
   charm:
     source: ./
     plugin: reactive
+    build-packages:
+      - libpython3-dev
     build-snaps:
       - charm
 


### PR DESCRIPTION
libpython3-dev is required to build cython.
See https://github.com/juju-solutions/layer-basic/pull/214

This problem is only evident now since we switched to charm 3.x in charmcraft builds in https://github.com/canonical/layer-filebeat/pull/115

ref. https://review.opendev.org/c/openstack/charm-keystone-ldap/+/880084